### PR TITLE
19 add pygbag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+*-pygbag.???
 MANIFEST
 
 # PyInstaller
@@ -162,3 +163,4 @@ cython_debug/
 
 event_handler.code-workspace
 misc_testing.py
+main.py

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@
 Simple Events is a simple system that uses decorator syntax to register functions to Pygame events, allowing those function to be fired whenever the assigned event occurs.
 It also features a keybind manager, which similarly can assign functions to remappable keybinds and controller binds.
 
+Simple Events also offers runtime-configurable compatibility with async-aware runtimes, such as pygbag.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 
@@ -132,7 +134,7 @@ Simple events also require Pygame Community edition to be installed.
 ## Usage
 
 EventManagers and KeyListeners are instantiated like loggers from the built-in python logging library.
-If you run basicConfig, it should be done in your main entry point, such as main.py or equivalent.
+If you run basicConfig, it should be done in your main entry point, such as main.py or equivalent. It needs to be run before your main game loop.
 
 <!--
 _For more examples, please refer to the [Documentation](https://example.com)_
@@ -230,7 +232,7 @@ KEYBINDS = simple_events.getKeyListener("Example")
 
 Key Listeners are seperate from event managers and can share handles without conflict.
 
-Key binds are slightly more involved. They require a bind name, and can accept an optional default key as well as mod keys. They have the same function signature requirements as regular event binds.
+Key binds are slightly more involved to set up than regular events. They require a bind name, and can accept an optional default key as well as mod keys. They have the same function signature requirements as regular event binds.
 
 ```python
 @KEYBINDS.bind("example_name", pygame.K_p, pygame.KMOD_SHIFT)
@@ -256,7 +258,7 @@ def some_function(_):
     # Something
     # When
     # Shift+P
-    # Is pressed
+    # Is released
 ```
 
 
@@ -274,7 +276,7 @@ def func2(_):
 
 In this example, pressing the "o" key will activate both functions, even though func2 asks for Ctrl+Z.
 
-If you are registering binds in multiple files, it may not always be obvious where your binds are being first called. You'll need to follow the chain of imports to figure it out. Alternatively, you can load a keymap file, which will guarantee control over your bindings.
+If you are registering binds in multiple files, it may not always be obvious where your binds are being first called. You'll need to follow the chain of imports to figure it out. Alternatively, you can load a keymap file, which will guarantee control over your bindings. A loaded keymap has the highest priority for specifying binds.
 
 Key Listeners also work with classes and methods, following similar syntax as the Event Manager.
 
@@ -301,7 +303,7 @@ KEYBINDS.rebind("example_name", pygame.K_m, pygame.KMOD_ALT)
 
 This changes the key for all functions bound to "example_name", which now get called when Alt+M is pressed instead of Shift+P.
 
-Key Maps and Joy Maps can also be saved and loaded from file. This requires a path to the desired file location, including the file name and extension. If the file type is supported, it will be intuited from the file extension. Unsupported file types can have a File Parser class passed to force a specific encoding.
+Key Maps and Joy Maps can also be saved and loaded from file. This requires a path to the desired file location, including the file name and extension. It supports almost any kind of path, including strings, and pathlib paths. If the file type is supported, it will be intuited from the file extension. Unsupported file types can have a File Parser class passed to force a specific encoding.
 
 ```python
 import simple_events
@@ -404,7 +406,7 @@ while game_is_running:
 The developer must track the managers and is responsible for feeding them the events. This allows greater control over if and when a given manager is activated.
 For example, it may be desirable to have a manager that handles menu functions, and another gameplay functions. This way, the game loop can test for game state, and run only the menu functions when in menu, and only gameplay functions while playing.
 
-Additionally, event managers and key listeners support calling _only_ sequential and _only_ concurrent functions and methods, if desired. This may be done using the \[manager\].notify_sequential(event) and \[manager\].notify_concurrent(event) methods, respectively. It should be noted that calling both the general and specific notifies on the same frame will call those functions twice.
+Additionally, event managers and key listeners support calling _only_ sequential and _only_ concurrent functions and methods, if desired. This may be done using the \[manager variable\].notify_sequential(event) and \[manager variable\].notify_concurrent(event) methods, respectively. It should be noted that calling both the general and specific notifies on the same frame will call those functions twice.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -420,13 +422,21 @@ Optionally, you can use
 ```
 to mark a function as sequential. Sequential functions and methods will called after the concurrent functions and methods, and will run one after the other. They lose out on being easily blockable, but reduce the risk of forming race conditions, especially if not sharing resources with any concurrent functions.
 
+The sequential tag is applied below the register or bind decorator.
+```python
+@KEYLISTENER.bind("test_bind", pygame.K_Space)
+@KEYLISTENER.sequential
+def test_func(event: pygame.Event) -> None:
+    # Some stuff
+```
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Async-Aware Concurrency
 
-when using an async-aware gameplay loop, such as with tools such as [pygbag](https://pypi.org/project/pygbag/), you'll need to change up the format of your concurrent functions and methods, as online pygame games made using pygbag do not work with traditional threads. Instead, you'll need to use asyncio.
+When using an async-aware gameplay loop, such as with tools such as [pygbag](https://pypi.org/project/pygbag/), you'll need to change up the format of your concurrent functions and methods, as online pygame games made using pygbag do not work with traditional threads. Instead, you'll need to use asyncio.
 
-With simple events, the transition is simple. Go from this:
+With Simple Events, the transition is simple. Go from this:
 ```python
 @EVENTS.register(pygame.MOUSEBUTTONUP)
 def mouse_click(event: pygame.Event) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygame_simple_events"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
     { name="BetterBuiltFool", email="betterbuiltfool@gmail.com"}
 ]

--- a/src/simple_events/__init__.py
+++ b/src/simple_events/__init__.py
@@ -1,4 +1,3 @@
-import sys
 from .base_manager import managerBasicConfig  # noqa: F401
 from .event_manager import getEventManager, notifyEventManagers  # noqa: F401, E501
 from .key_manager import getKeyListener, notifyKeyListeners  # noqa: F401, E501
@@ -7,8 +6,3 @@ from .file_parser import JSONParser  # noqa: F401, E501
 
 def basicConfig(*args, **kwds):
     managerBasicConfig(*args, **kwds)
-
-
-if sys.platform == "emscripten":
-    # We always want to run in async mode if we're online
-    basicConfig(is_async=True)

--- a/src/simple_events/__init__.py
+++ b/src/simple_events/__init__.py
@@ -1,3 +1,9 @@
+import sys
+from .base_manager import basicConfig  # noqa: F401
 from .event_manager import getEventManager, notifyEventManagers  # noqa: F401, E501
 from .key_manager import getKeyListener, notifyKeyListeners  # noqa: F401, E501
 from .file_parser import JSONParser  # noqa: F401, E501
+
+if sys.platform == "emscripten":
+    # We always want to run in async mode if we're online
+    basicConfig(is_async=True)

--- a/src/simple_events/__init__.py
+++ b/src/simple_events/__init__.py
@@ -1,8 +1,13 @@
 import sys
-from .base_manager import basicConfig  # noqa: F401
+from .base_manager import managerBasicConfig  # noqa: F401
 from .event_manager import getEventManager, notifyEventManagers  # noqa: F401, E501
 from .key_manager import getKeyListener, notifyKeyListeners  # noqa: F401, E501
 from .file_parser import JSONParser  # noqa: F401, E501
+
+
+def basicConfig(*args, **kwds):
+    managerBasicConfig(*args, **kwds)
+
 
 if sys.platform == "emscripten":
     # We always want to run in async mode if we're online

--- a/src/simple_events/base_manager.py
+++ b/src/simple_events/base_manager.py
@@ -248,7 +248,7 @@ class BaseManager(ABC):
         return wrapper
 
 
-def basicConfig(*args, **kwds) -> None:
+def managerBasicConfig(*args, **kwds) -> None:
     if kwds.get("is_async", False):
         BaseManager.thread_system = AsyncThreadSystem()
     else:

--- a/src/simple_events/base_manager.py
+++ b/src/simple_events/base_manager.py
@@ -41,7 +41,7 @@ class DefaultThreadSystem(_BaseThreadSystem):
 
 class AsyncThreadSystem(_BaseThreadSystem):
     def start_thread(self, callable, *args):
-        asyncio.ensure_future(callable(*args))
+        asyncio.create_task(callable(*args))
 
 
 class BaseManager(ABC):

--- a/src/simple_events/key_manager.py
+++ b/src/simple_events/key_manager.py
@@ -507,7 +507,7 @@ class KeyListener(BaseManager):
 
     @classmethod
     def load_from_file(
-        cls, file_path: PathLike, parser: Optional[Type[FileParser]] = None
+        cls, file_path: PathLike | str, parser: Optional[Type[FileParser]] = None
     ) -> None:
         """
         Pulls the file from the file path, and uses the supplied parser to convert the
@@ -534,7 +534,7 @@ class KeyListener(BaseManager):
 
     @classmethod
     def save_to_file(
-        cls, file_path: PathLike, parser: Optional[Type[FileParser]] = None
+        cls, file_path: PathLike | str, parser: Optional[Type[FileParser]] = None
     ) -> None:
         """
         Saves the current KeyMap and JoyMap to a file in the requested location.

--- a/src/simple_events/key_manager.py
+++ b/src/simple_events/key_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+from os import PathLike
 from pathlib import Path
 from typing import Any, Callable, Optional, overload, Type
 
@@ -506,7 +507,7 @@ class KeyListener(BaseManager):
 
     @classmethod
     def load_from_file(
-        cls, file_path: Path, parser: Optional[Type[FileParser]] = None
+        cls, file_path: PathLike, parser: Optional[Type[FileParser]] = None
     ) -> None:
         """
         Pulls the file from the file path, and uses the supplied parser to convert the
@@ -523,6 +524,8 @@ class KeyListener(BaseManager):
         :raises ValueError: Raised if not parser is given, and the file type is not
         supported.
         """
+        if type(file_path) is not Path:
+            file_path = Path(file_path)
         parser = parser or _get_parser_from_path(file_path)
         with open(file_path, "r") as file:
             key_binds, joy_binds = parser.load(file)
@@ -531,7 +534,7 @@ class KeyListener(BaseManager):
 
     @classmethod
     def save_to_file(
-        cls, file_path: Path, parser: Optional[Type[FileParser]] = None
+        cls, file_path: PathLike, parser: Optional[Type[FileParser]] = None
     ) -> None:
         """
         Saves the current KeyMap and JoyMap to a file in the requested location.
@@ -545,6 +548,8 @@ class KeyListener(BaseManager):
         :raises ValueError: Raised if not parser is given, and the file type is not
         supported.
         """
+        if type(file_path) is not Path:
+            file_path = Path(file_path)
         parser = parser or _get_parser_from_path(file_path)
         with open(file_path, "w") as file:
             parser.save(cls.key_map, cls.joy_map, file)


### PR DESCRIPTION
Makes some under-the-hood changes to support running greenthreads instead of regular threads. This allows pygbag applications to run with concurrency and blocking without blocking the rest of the program. This requires using async syntax, though, and requires specifying that mode via a config function.

Additionally, there is now infrastructure for running config to customize behavior. Currently it only supports changing to or from async mode.